### PR TITLE
Make initial jump size configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "skip_ratchet"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_ratchet"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Skip ratchet"
 keywords = ["wnfs", "webnative", "skip-ratchet", "decentralisation"]

--- a/proptest-regressions/tests.txt
+++ b/proptest-regressions/tests.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 6f6001ada6b4d98bfb2462ee2e32576a6c4f5c08c0a93c5d95887f861273cf88 # shrinks to input = _PropRatchetExpSearchFindsOnlyGreaterAndLessArgs { seed: [221, 54, 116, 160, 176, 65, 176, 63, 13, 40, 189, 202, 110, 210, 126, 173, 246, 170, 251, 22, 142, 122, 192, 194, 159, 185, 219, 112, 232, 66, 87, 145], jump: 1 }
+cc cecd4dd38b08775691d01626390a752e1552ee077407ff1cfd78976fb8ff3651 # shrinks to input = _PropRatchetExpSearchFindsZeroArgs { seed: [93, 158, 191, 63, 126, 150, 51, 240, 53, 197, 162, 47, 118, 235, 250, 51, 162, 97, 78, 208, 165, 201, 187, 129, 55, 248, 50, 145, 127, 232, 143, 179], initial_jump_size: Small }


### PR DESCRIPTION
Also: Rename `Epoch` to `JumpSize` and make it public (but not its methods).

The previous default for the initial jump size was `JumpSize::Zero`.
I noticed that in rs-wnfs we'll likely want that to be `JumpSize::Small`.
In the typescript implementation the initial jump size was the equivalent of `JumpSize::Large`, but hard-coded.

I don't think this library should hard-code this choice, different use cases would like to choose different initial jump sizes.

This doesn't have any effect on the correctness of the search algorithm: The same ratchet must be found irrespective of the initial jump size used.
This property can be seen in the tests. The initial jump size is initialized randomly.

