### PR TITLE
Rename `RatchetExpSearcher` back to `RatchetSeeker`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "skip_ratchet"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_ratchet"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Skip ratchet"
 keywords = ["wnfs", "webnative", "skip-ratchet", "decentralisation"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 mod constants;
 mod errors;
-pub mod exp_search;
 mod hash;
 pub mod ratchet;
+pub mod seek;
 
 #[cfg(test)]
 mod tests;
 
 pub use errors::*;
-pub use exp_search::RatchetExpSearcher;
 pub use ratchet::Ratchet;
+pub use seek::RatchetSeeker;

--- a/src/seek.rs
+++ b/src/seek.rs
@@ -44,9 +44,11 @@ impl JumpSize {
     }
 }
 
-/// The ratchet exponential searcher looks for a specific ratchet
-/// by efficiently jumping multiple steps ahead.
-pub struct RatchetExpSearcher {
+/// The ratchet seeker looks for a target ratchet
+/// by efficiently exploring the ratchet space and
+/// figuring out whether it's smaller or greater than
+/// the target until it finds the target.
+pub struct RatchetSeeker {
     /// Invariant: minimum is always smaller than or equal to the seeked ratchet
     minimum: Ratchet,
     /// Invariant: current is the next jump_size-ed jump bigger than minimum
@@ -59,7 +61,7 @@ pub struct RatchetExpSearcher {
     max_jump_size: JumpSize,
 }
 
-impl RatchetExpSearcher {
+impl RatchetSeeker {
     /// Start a new ratchet search.
     ///
     /// The assumption is that given ratchet is less or equal to the target


### PR DESCRIPTION
Seems like `seek` is a more concise for this: https://www.computer-dictionary-online.org/definitions-s/seek.html
The term is more abstract than only file seeks.
