### PR TITLE
Fix ratchet iterator API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "skip_ratchet"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_ratchet"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Skip ratchet"
 keywords = ["wnfs", "webnative", "skip-ratchet", "decentralisation"]

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -473,7 +473,8 @@ impl Iterator for Ratchet {
     type Item = Ratchet;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(self.next_small_epoch())
+        self.inc();
+        Some(self.clone())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -262,6 +262,19 @@ fn test_ratchet_previous_budget() {
     }
 }
 
+#[test]
+fn test_ratchet_iterator() {
+    let mut ratchet = Ratchet::zero(hash_from_hex(SEED).into());
+    let mut via_iterator = ratchet.clone();
+
+    ratchet.inc();
+    assert_ratchet_equal(&ratchet, &via_iterator.next().unwrap());
+    ratchet.inc();
+    assert_ratchet_equal(&ratchet, &via_iterator.next().unwrap());
+    ratchet.inc();
+    assert_ratchet_equal(&ratchet, &via_iterator.next().unwrap());
+}
+
 fn assert_ratchet_equal(expected: &Ratchet, got: &Ratchet) {
     assert_eq!(expected.large, got.large);
     assert_eq!(expected.medium, got.medium);


### PR DESCRIPTION
Previously, calling `next()` on a `mut Ratchet` would always give you back the same ratchet. I think that's not what one would expect from iterators. Now it actually both returns a clone of the ratchet & it steps the ratchet forward one step.

