### PR TITLE
fix: Encode hashes as bytes, not lists of varints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 base64 = "0.21"
 hex = "=0.4"
+rand_core = "0.6.2"
 rand = "=0.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha3 = "=0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "Apache-2.0"
 base64 = "0.21"
 hex = "=0.4"
 rand_core = "0.6.2"
-rand = "=0.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha3 = "=0.10"
 
@@ -24,6 +23,7 @@ serde = ["dep:serde"]
 [dev-dependencies]
 proptest = "1.0"
 test-strategy = "0.3"
+rand = "=0.8"
 
 [profile.test]
 opt-level = 3

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -7,7 +7,9 @@ use std::{
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash(
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_byte_array"))] pub [u8; 32],
+);
 
 impl Hash {
     /// Creates a new Hash from last hash of `n` consecutive hashes of an item.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ mod errors;
 mod hash;
 pub mod ratchet;
 pub mod seek;
+#[cfg(feature = "serde")]
+mod serde_byte_array;
 
 #[cfg(test)]
 mod tests;

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -18,7 +18,7 @@ use std::fmt::{self, Display, Formatter};
 /// ```
 /// use skip_ratchet::Ratchet;
 ///
-/// let ratchet = Ratchet::new(&mut rand::thread_rng());
+/// let ratchet = Ratchet::from_rng(&mut rand::thread_rng());
 /// let key = ratchet.derive_key();
 /// ```
 ///
@@ -41,7 +41,7 @@ pub struct Ratchet {
 /// ```
 /// use skip_ratchet::Ratchet;
 ///
-/// let mut old_ratchet = Ratchet::new(&mut rand::thread_rng());
+/// let mut old_ratchet = Ratchet::from_rng(&mut rand::thread_rng());
 /// old_ratchet.inc_by(10);
 ///
 /// let mut recent_ratchet = old_ratchet.clone();
@@ -67,7 +67,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// ```
     pub fn from_rng(rng: &mut impl CryptoRngCore) -> Self {
         // 32 bytes for the seed, plus two extra bytes to randomize small & medium starts
@@ -110,7 +110,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// let key = ratchet.derive_key();
     /// ```
     pub fn derive_key(&self) -> [u8; 32] {
@@ -124,7 +124,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// ratchet.inc();
     /// ```
     pub fn inc(&mut self) {
@@ -144,7 +144,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// ratchet.inc_by(3);
     ///
     /// println!("{:?}", String::from(&ratchet));
@@ -204,7 +204,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet1 = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet1 = Ratchet::from_rng(&mut rand::thread_rng());
     /// ratchet1.inc();
     ///
     /// let mut ratchet2 = ratchet1.clone();
@@ -225,7 +225,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut old_ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut old_ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// old_ratchet.inc_by(10);
     ///
     /// let mut recent_ratchet = old_ratchet.clone();
@@ -256,7 +256,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// ratchet.inc_by(10);
     ///
     /// println!("{:?}", ratchet.combined_counter());
@@ -272,7 +272,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// let (r, s) = ratchet.next_large_epoch();
     /// ```
     pub fn next_large_epoch(&self) -> (Ratchet, usize) {
@@ -289,7 +289,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// let (r, s) = ratchet.next_medium_epoch();
     /// ```
     pub fn next_medium_epoch(&self) -> (Ratchet, usize) {
@@ -316,7 +316,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let mut ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// let r = ratchet.next_small_epoch();
     /// ```
     pub fn next_small_epoch(&self) -> Ratchet {
@@ -395,7 +395,7 @@ impl PreviousIterator {
     /// ```
     /// use skip_ratchet::{Ratchet, ratchet::PreviousIterator};
     ///
-    /// let old_ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let old_ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     ///
     /// let mut new_ratchet = old_ratchet.clone();
     /// new_ratchet.inc_by(100_000);
@@ -446,7 +446,7 @@ impl PreviousIterator {
     /// ```
     /// use skip_ratchet::{Ratchet, ratchet::PreviousIterator};
     ///
-    /// let old_ratchet = Ratchet::new(&mut rand::thread_rng());
+    /// let old_ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     /// let mut new_ratchet = old_ratchet.clone();
     /// new_ratchet.inc_by(100_000);
     ///

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Display, Formatter};
 /// ```
 /// use skip_ratchet::Ratchet;
 ///
-/// let ratchet = Ratchet::new();
+/// let ratchet = Ratchet::new(&mut rand::thread_rng());
 /// let key = ratchet.derive_key();
 /// ```
 ///
@@ -40,7 +40,7 @@ pub struct Ratchet {
 /// ```
 /// use skip_ratchet::Ratchet;
 ///
-/// let mut old_ratchet = Ratchet::new();
+/// let mut old_ratchet = Ratchet::new(&mut rand::thread_rng());
 /// old_ratchet.inc_by(10);
 ///
 /// let mut recent_ratchet = old_ratchet.clone();
@@ -66,7 +66,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let ratchet = Ratchet::new();
+    /// let ratchet = Ratchet::new(&mut rand::thread_rng());
     /// ```
     pub fn new(rng: &mut impl RngCore) -> Self {
         // 32 bytes for the seed, plus two extra bytes to randomize small & medium starts
@@ -109,7 +109,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let ratchet = Ratchet::new();
+    /// let ratchet = Ratchet::new(&mut rand::thread_rng());
     /// let key = ratchet.derive_key();
     /// ```
     pub fn derive_key(&self) -> [u8; 32] {
@@ -123,7 +123,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// ratchet.inc();
     /// ```
     pub fn inc(&mut self) {
@@ -143,7 +143,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// ratchet.inc_by(3);
     ///
     /// println!("{:?}", String::from(&ratchet));
@@ -203,7 +203,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet1 = Ratchet::new();
+    /// let mut ratchet1 = Ratchet::new(&mut rand::thread_rng());
     /// ratchet1.inc();
     ///
     /// let mut ratchet2 = ratchet1.clone();
@@ -224,7 +224,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut old_ratchet = Ratchet::new();
+    /// let mut old_ratchet = Ratchet::new(&mut rand::thread_rng());
     /// old_ratchet.inc_by(10);
     ///
     /// let mut recent_ratchet = old_ratchet.clone();
@@ -255,7 +255,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// ratchet.inc_by(10);
     ///
     /// println!("{:?}", ratchet.combined_counter());
@@ -271,7 +271,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// let (r, s) = ratchet.next_large_epoch();
     /// ```
     pub fn next_large_epoch(&self) -> (Ratchet, usize) {
@@ -288,7 +288,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// let (r, s) = ratchet.next_medium_epoch();
     /// ```
     pub fn next_medium_epoch(&self) -> (Ratchet, usize) {
@@ -315,7 +315,7 @@ impl Ratchet {
     /// ```
     /// use skip_ratchet::Ratchet;
     ///
-    /// let mut ratchet = Ratchet::new();
+    /// let mut ratchet = Ratchet::new(&mut rand::thread_rng());
     /// let r = ratchet.next_small_epoch();
     /// ```
     pub fn next_small_epoch(&self) -> Ratchet {
@@ -394,7 +394,7 @@ impl PreviousIterator {
     /// ```
     /// use skip_ratchet::{Ratchet, ratchet::PreviousIterator};
     ///
-    /// let old_ratchet = Ratchet::new();
+    /// let old_ratchet = Ratchet::new(&mut rand::thread_rng());
     ///
     /// let mut new_ratchet = old_ratchet.clone();
     /// new_ratchet.inc_by(100_000);
@@ -445,7 +445,7 @@ impl PreviousIterator {
     /// ```
     /// use skip_ratchet::{Ratchet, ratchet::PreviousIterator};
     ///
-    /// let old_ratchet = Ratchet::new();
+    /// let old_ratchet = Ratchet::new(&mut rand::thread_rng());
     /// let mut new_ratchet = old_ratchet.clone();
     /// new_ratchet.inc_by(100_000);
     ///

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -4,7 +4,6 @@ use crate::{
     PreviousErr, RatchetErr,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rand::Rng;
 use rand_core::CryptoRngCore;
 use std::fmt::{self, Display, Formatter};
 
@@ -71,12 +70,15 @@ impl Ratchet {
     /// ```
     pub fn from_rng(rng: &mut impl CryptoRngCore) -> Self {
         // 32 bytes for the seed, plus two extra bytes to randomize small & medium starts
-        let seed = Hash::from_raw(rng.gen::<[u8; 32]>());
+        let mut seed_raw = [0u8; 32];
+        rng.fill_bytes(&mut seed_raw);
+        let seed = Hash::from_raw(seed_raw);
         let medium = Hash::from(&!seed);
         let small = Hash::from(&!medium);
 
-        let inc_med = rng.gen::<u8>();
-        let inc_small = rng.gen::<u8>();
+        let mut incs = [0u8; 2];
+        rng.fill_bytes(&mut incs);
+        let [inc_med, inc_small] = incs;
 
         Ratchet {
             large: Hash::from(&seed),

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -4,7 +4,8 @@ use crate::{
     PreviousErr, RatchetErr,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rand::{Rng, RngCore};
+use rand::Rng;
+use rand_core::CryptoRngCore;
 use std::fmt::{self, Display, Formatter};
 
 /// A (Skip) `Ratchet` is a data structure for deriving keys that maintain backward secrecy.
@@ -59,7 +60,7 @@ pub struct PreviousIterator {
 }
 
 impl Ratchet {
-    /// Creates a new ratchet with a randomly generated seed.
+    /// Creates a randomly-generated Skip Ratchet.
     ///
     /// # Examples
     ///
@@ -68,7 +69,7 @@ impl Ratchet {
     ///
     /// let ratchet = Ratchet::new(&mut rand::thread_rng());
     /// ```
-    pub fn new(rng: &mut impl RngCore) -> Self {
+    pub fn from_rng(rng: &mut impl CryptoRngCore) -> Self {
         // 32 bytes for the seed, plus two extra bytes to randomize small & medium starts
         let seed = Hash::from_raw(rng.gen::<[u8; 32]>());
         let medium = Hash::from(&!seed);

--- a/src/serde_byte_array.rs
+++ b/src/serde_byte_array.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Deserializer, Serializer};
+
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bytes: Vec<u8> = Vec::deserialize(deserializer)?;
+    let slice: [u8; 32] = bytes
+        .try_into()
+        .map_err(|x: Vec<u8>| serde::de::Error::invalid_length(x.len(), &"32"))?;
+    Ok(slice)
+}
+
+pub(crate) fn serialize<S>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_bytes(bytes)
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -278,7 +278,7 @@ fn test_ratchet_iterator() {
 
 #[test]
 fn test_step_count_regression() {
-    let old_ratchet = Ratchet::new();
+    let old_ratchet = Ratchet::new(&mut rand::thread_rng());
     let mut new_ratchet = old_ratchet.clone();
     new_ratchet.inc_by(LARGE_EPOCH_LENGTH + 10);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -278,7 +278,7 @@ fn test_ratchet_iterator() {
 
 #[test]
 fn test_step_count_regression() {
-    let old_ratchet = Ratchet::new(&mut rand::thread_rng());
+    let old_ratchet = Ratchet::from_rng(&mut rand::thread_rng());
     let mut new_ratchet = old_ratchet.clone();
     new_ratchet.inc_by(LARGE_EPOCH_LENGTH + 10);
 


### PR DESCRIPTION
Previously, encoding a `Ratchet` with serde would serialize each internal hash state using a list of integers in serde's data model, instead of a simple 32-byte array.

I also added a `&mut impl RngCore` parameter to `new`, instead of that depending on `rand::thread_rng()` internally.