### PR TITLE
feat: Fix serialization failing to round trip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,17 @@ license = "Apache-2.0"
 hex = "0.4"
 rand_core = "0.6.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_bytes = { version = "0.11", optional = true }
 sha3 = "0.10"
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_bytes"]
 
 [dev-dependencies]
 proptest = "1.0"
 test-strategy = "0.3"
 rand = "0.8"
+libipld = { version = "0.16", features = ["dag-cbor", "derive", "serde-codec"] }
 
 [profile.test]
 opt-level = 3

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,6 @@ pub enum RatchetErr {
 #[derive(Debug, PartialEq, Eq)]
 pub enum PreviousErr {
     BudgetExceeded,
-    EqualRatchets,
     OlderRatchet,
 }
 
@@ -35,7 +34,6 @@ impl Display for PreviousErr {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             PreviousErr::BudgetExceeded => write!(f, "ratchet discrepancy budget exceeded"),
-            PreviousErr::EqualRatchets => write!(f, "ratchets are equal"),
             PreviousErr::OlderRatchet => write!(f, "current ratchet is older than given ratchet"),
         }
     }

--- a/src/previous.rs
+++ b/src/previous.rs
@@ -191,18 +191,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ratchet_previous_equal_error() {
-        let old = Ratchet::zero(salt(), &seed());
-        match old.previous(&old, 10) {
-            Ok(_) => panic!("expected PreviousErr::EqualRatchets, got an iterator instead"),
-            Err(e) => match e {
-                PreviousErr::EqualRatchets => (),
-                _ => panic!("expected PreviousErr::EqualRatchets, got {e:?}"),
-            },
-        }
-    }
-
-    #[test]
     fn test_ratchet_previous_older_error() {
         let old = Ratchet::zero(salt(), &seed());
         let mut recent = old.clone();

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -253,9 +253,7 @@ impl Ratchet {
         old: &Ratchet,
         discrepancy_budget: usize,
     ) -> Result<PreviousIterator, PreviousErr> {
-        if self == old {
-            return Err(PreviousErr::EqualRatchets);
-        } else if old.known_after(self) {
+        if old.known_after(self) {
             return Err(PreviousErr::OlderRatchet);
         }
 

--- a/src/serde_byte_array.rs
+++ b/src/serde_byte_array.rs
@@ -1,10 +1,10 @@
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{Deserializer, Serializer};
 
 pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
 where
     D: Deserializer<'de>,
 {
-    let bytes: Vec<u8> = Vec::deserialize(deserializer)?;
+    let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
     let slice: [u8; 32] = bytes
         .try_into()
         .map_err(|x: Vec<u8>| serde::de::Error::invalid_length(x.len(), &"32"))?;
@@ -15,5 +15,5 @@ pub(crate) fn serialize<S>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::
 where
     S: Serializer,
 {
-    serializer.serialize_bytes(bytes)
+    serde_bytes::serialize(bytes.as_ref(), serializer)
 }


### PR DESCRIPTION
Two fixes:
- Ratchet serialization now successfully round-trips
- Calling `.previous` given two equal ratchets shouldn't error out, but just provide you with an empty iterator